### PR TITLE
update: Node v20 and Alpine 3.20

### DIFF
--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.10-alpine3.14
+FROM node:20-alpine
 
 RUN apk --no-cache add curl git zsh sudo docker-cli docker-compose
 


### PR DESCRIPTION
- reasoning: cloning the frontend in a dev container in vscode results in a unsupported alpine image error